### PR TITLE
Improve error handling for invalid JSON body

### DIFF
--- a/server.js
+++ b/server.js
@@ -84,7 +84,11 @@ app.post('/api/nowplaying', async (req, res) => {
     try {
       data = JSON.parse(req.body); // attempt to parse the text as JSON
     } catch {
-      return res.status(400).json({ error: "Body was not valid JSON" });
+      if (typeof data == "string"){
+        return res.status(400).json({ error: "Body was a string"});
+      }else{
+      return res.status(400).json({ error: "Body was not valid JSON"});
+      }
     }
 
     if (!data.title || !data.artist) {


### PR DESCRIPTION
Adds a specific error response when the request body is a string, distinguishing it from other invalid JSON cases in the /api/nowplaying endpoint.