### PR TITLE
Remove unused dateChanged field from nowplaying API

### DIFF
--- a/server.js
+++ b/server.js
@@ -97,7 +97,6 @@ app.post('/api/nowplaying', async (req, res) => {
         title: data.title,
         type: data.type,
         typeNo: data.typeNo,
-        dateChanged: data.date,
         timestamp: new Date().toISOString()
       }
     };


### PR DESCRIPTION
The dateChanged field was removed from the response object in the /api/nowplaying endpoint as it is no longer needed.